### PR TITLE
Update config.yml

### DIFF
--- a/ClearLag/config.yml
+++ b/ClearLag/config.yml
@@ -99,7 +99,7 @@ mob-range:
 live-time:
   enabled: true
   interval: 10
-  mobtimer: true
+  mobtimer: false
   itemtimer: true
   arrowtimer: true
   arrowkilltime: 15


### PR DESCRIPTION
Change mobtimer to false on line 102. Mobs where being culled 5 minutes (6000 ticks) after spawning.